### PR TITLE
Add save image as PNG button

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -77,7 +77,8 @@ export default class ImagePreviewProvider
         JSON.stringify(newDocument.imageData),
         width || 0,
         height || 0,
-        imgType || ""
+        imgType || "",
+        webviewPanel.title
       );
     }
   }

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -1,13 +1,16 @@
 import * as vscode from "vscode";
 import validateColor from "validate-color";
 import { imagePreviewProviderViewType } from "./const";
+import * as path from 'path';
 
 const generateHTMLCanvas = (
   data: string,
   width: number,
   height: number,
-  imgType: string
+  imgType: string,
+  webviewTitle: string
 ): string => {
+  const saveFilename = `${path.basename(webviewTitle, path.extname(webviewTitle))}.png`;
   const bgColor = String(vscode.workspace.getConfiguration(imagePreviewProviderViewType).get('panelBackgroundColor'));
   const btnColor = String(vscode.workspace.getConfiguration(imagePreviewProviderViewType).get('panelButtonColor'));
   const styles = {
@@ -100,7 +103,7 @@ const generateHTMLCanvas = (
             const saveLink = document.createElement("a");
             showImg(1); // scale image to 100% 
             saveLink.href = canvas.toDataURL();
-            saveLink.download = "image.png";
+            saveLink.download = '${saveFilename}';
             saveLink.click();
             showImg(scale); // restore zoom level
           }

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -67,11 +67,12 @@ const generateHTMLCanvas = (
           const widthDisplay = document.getElementById('width-display');
           const heightDisplay = document.getElementById('height-display');
           const scaleDisplay = document.getElementById('scale-display');
-          function showImg(scale) {
-            const { colorData, width, height, imgType } = message;
-            let ctx = canvas.getContext('2d');
-            canvas.width = width * scale;
-            canvas.height = height * scale;
+
+          function scaleCanvas(targetCanvas, scale) {
+            const { colorData, width, height } = message;
+            let ctx = targetCanvas.getContext('2d');
+            targetCanvas.width = width * scale;
+            targetCanvas.height = height * scale;
             for (let x = 0; x < width; x++){
               for (let y = 0; y < height; y++){
                 let color = colorData[(y * width) + x];
@@ -79,6 +80,11 @@ const generateHTMLCanvas = (
                 ctx.fillRect(x * scale, y * scale, scale, scale);
               }
             }
+          }
+
+          function showImg(scale) {
+            const { width, height, imgType } = message;
+            scaleCanvas(canvas, scale);
             typeDisplay.innerHTML = "Type: " + imgType;
             widthDisplay.innerHTML = "Width: " + String(width) + "px";
             heightDisplay.innerHTML = "Height: " + String(height) + "px";
@@ -101,11 +107,11 @@ const generateHTMLCanvas = (
 
           function saveImg() {
             const saveLink = document.createElement("a");
-            showImg(1); // scale image to 100% 
-            saveLink.href = canvas.toDataURL();
+            const saveCanvas = canvas.cloneNode(true);
+            scaleCanvas(saveCanvas, 1);
+            saveLink.href = saveCanvas.toDataURL();
             saveLink.download = '${saveFilename}';
             saveLink.click();
-            showImg(scale); // restore zoom level
           }
 
           const lastPos = { x: 0, y: 0 };

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -50,7 +50,7 @@ const generateHTMLCanvas = (
             <div onclick="scale = scale / 2; showImg(scale);" style="${styles.sizingButton}">-</div>
           </div>
           <div onclick="scale = 1; showImg(scale);" style="${styles.wideButton}">Reset</div>
-          <div onclick="saveImg();" style="${styles.wideButton}">Save Image</div>
+          <div onclick="saveImg();" style="${styles.wideButton}">Save as PNG</div>
         </div>
         <div id="canvas-container" style="overflow: auto">
           <canvas width="${width}" height="${height}" id="canvas-area" style="${styles.canvas}"></canvas>

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -25,7 +25,7 @@ const generateHTMLCanvas = (
                   text-align: center;
                   cursor: pointer;
                   user-select: none;`,
-    resetButton: `background-color: ${validateColor(btnColor) ? btnColor : "#dd4535"};
+    wideButton: `background-color: ${validateColor(btnColor) ? btnColor : "#dd4535"};
                   text-align: center;
                   margin-bottom: 15px;
                   cursor: pointer;
@@ -49,7 +49,8 @@ const generateHTMLCanvas = (
             <div onclick="scale = scale * 2; showImg(scale);" style="${styles.sizingButton}">+</div>
             <div onclick="scale = scale / 2; showImg(scale);" style="${styles.sizingButton}">-</div>
           </div>
-          <div onclick="scale = 1; showImg(scale);" style="${styles.resetButton}">Reset</div>
+          <div onclick="scale = 1; showImg(scale);" style="${styles.wideButton}">Reset</div>
+          <div onclick="saveImg();" style="${styles.wideButton}">Save Image</div>
         </div>
         <div id="canvas-container" style="overflow: auto">
           <canvas width="${width}" height="${height}" id="canvas-area" style="${styles.canvas}"></canvas>
@@ -94,6 +95,13 @@ const generateHTMLCanvas = (
           }
 
           window.addEventListener('wheel', zoom);
+
+          function saveImg() {
+            const saveLink = document.createElement("a");
+            saveLink.href = canvas.toDataURL();
+            saveLink.download = "image.png";
+            saveLink.click();
+          }
 
           const lastPos = { x: 0, y: 0 };
           let isDragging = false;

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -98,9 +98,11 @@ const generateHTMLCanvas = (
 
           function saveImg() {
             const saveLink = document.createElement("a");
+            showImg(1); // scale image to 100% 
             saveLink.href = canvas.toDataURL();
             saveLink.download = "image.png";
             saveLink.click();
+            showImg(scale); // restore zoom level
           }
 
           const lastPos = { x: 0, y: 0 };

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import validateColor from "validate-color";
 import { imagePreviewProviderViewType } from "./const";
-import * as path from 'path';
+import * as path from "path";
 
 const generateHTMLCanvas = (
   data: string,


### PR DESCRIPTION
Hi, I've added a save image button. 
I had used screenshots to save images, but it didn't save a image cleanly.
So, I implemented saving image(png) feature using `HTMLCanvasElement.toDataURL()` ([document](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL)) .
![image](https://user-images.githubusercontent.com/39793156/143728184-64ffee90-3e9d-4beb-a9f6-c7948f458586.png)

I would like to discuss about size of the image to be saved.
In the current implementation.  the size of the saved image depends on the zoom level(canvas size).
For example. an image with a zoom level of 200% will be larger than an image with a zoom level of 100%.
Should we keep this implementation or fix the size of the image to be saved?

I tested the feature in Windows, MacOS, and wsl, and It worked.
Please review this pull request when you have time. Thanks!

### Changes
- change class name 'resetButton' to 'wideButton'
- add `saveImg()` function to save canvas image