### PR TITLE
Add headless rendering mode for rendering function

### DIFF
--- a/src/webview/script.js
+++ b/src/webview/script.js
@@ -96,15 +96,12 @@ const updateSourceCanvas = () => {
 const renderScaledImage = (targetCanvas, scale, headless) => {
   if (!sourceCanvas) return;
 
-  let dpr = window.devicePixelRatio || 1;
-  if (headless) {
-    scale = 1;
-    dpr = 1;
-  }
+  const dpr = window.devicePixelRatio || 1;
+  if (headless) scale = 1.0;
 
-  const effectiveScale = scale * dpr;
-  const targetW = Math.round(state.width * scale * dpr);
-  const targetH = Math.round(state.height * scale * dpr);
+  const effectiveScale = headless ? 1.0 : scale * dpr;
+  const targetW = Math.round(state.width * effectiveScale);
+  const targetH = Math.round(state.height * effectiveScale);
 
   targetCanvas.width = targetW;
   targetCanvas.height = targetH;

--- a/src/webview/script.js
+++ b/src/webview/script.js
@@ -205,7 +205,7 @@ const savePNGImage = () => {
   const saveLink = document.createElement('a');
 
   const saveCanvas = canvasNode.cloneNode(true);
-  renderScaledImage(saveCanvas, 1, true);
+  renderScaledImage(saveCanvas, 1.0, true);
 
   saveLink.href = saveCanvas.toDataURL();
   saveLink.download = state.saveFilename;

--- a/src/webview/script.js
+++ b/src/webview/script.js
@@ -93,10 +93,15 @@ const updateSourceCanvas = () => {
 };
 
 // Render the image data to the canvas
-const renderScaledImage = (targetCanvas, scale) => {
+const renderScaledImage = (targetCanvas, scale, headless) => {
   if (!sourceCanvas) return;
 
-  const dpr = window.devicePixelRatio || 1;
+  let dpr = window.devicePixelRatio || 1;
+  if (headless) {
+    scale = 1;
+    dpr = 1;
+  }
+
   const effectiveScale = scale * dpr;
   const targetW = Math.round(state.width * scale * dpr);
   const targetH = Math.round(state.height * scale * dpr);
@@ -191,7 +196,7 @@ const scaleImage = (factor) => {
     state.scale = 1.0;
   }
 
-  renderScaledImage(canvasNode, state.scale);
+  renderScaledImage(canvasNode, state.scale, false);
   updateUI();
 };
 
@@ -200,7 +205,7 @@ const savePNGImage = () => {
   const saveLink = document.createElement('a');
 
   const saveCanvas = canvasNode.cloneNode(true);
-  renderScaledImage(saveCanvas, 1.0);
+  renderScaledImage(saveCanvas, 1, true);
 
   saveLink.href = saveCanvas.toDataURL();
   saveLink.download = state.saveFilename;
@@ -309,7 +314,7 @@ const registerMessageHandlers = () => {
         state.saveFilename = message.payload.saveFilename;
 
         updateSourceCanvas();
-        renderScaledImage(canvasNode, state.scale);
+        renderScaledImage(canvasNode, state.scale, false);
         updateUI();
         break;
       case 'extension-settings-push':
@@ -317,7 +322,7 @@ const registerMessageHandlers = () => {
 
         // Apply before updating UI because we change the scale here
         applyExtensionSettings();
-        renderScaledImage(canvasNode, state.scale);
+        renderScaledImage(canvasNode, state.scale, false);
 
         updateUI();
         break;


### PR DESCRIPTION
Hi @nagata-yoshiteru, as reported in #63, the `dpr` value in `renderScaledImage` seems to return 2 (at least on macos). This leads to the image being scaled 2x on saving, even when the scale factor that is passed in the save function is 1.
I've added a headless rendering mode, though Im not sure if that's the right name for it. Basically we just force the `dpr` and `scale` to 1 for headless renders.

@cesmoak just to make sure this makes sense. Thanks!

I'm open to changing the name of the param because I'm not sure if calling it headless is the right term.
Thanks all!